### PR TITLE
Fix type of SSA1.IRQActive

### DIFF
--- a/source/sa1.h
+++ b/source/sa1.h
@@ -119,7 +119,7 @@ typedef struct
    uint32_t  Flags;
    bool   Executing;
    bool   NMIActive;
-   bool   IRQActive;
+   uint8_t   IRQActive;
    bool   WaitingForInterrupt;
    bool   Waiting;
    //    uint8_t   WhichEvent;


### PR DESCRIPTION
Exact same issue as the main CPU fixed here: https://github.com/libretro/snes9x2005/commit/735bc9b39a4eb1de6aef4c4b1af6e0b48d578bde

Fixes https://github.com/libretro/snes9x2005/issues/13 maybe others.