### PR TITLE
Use git version as library_version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ TARGET_NAME := snes9x2005_plus
 else
 TARGET_NAME := snes9x2005
 endif
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 DEFS        :=
 LIBM        := -lm

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,4 +1,8 @@
 LOCAL_PATH := $(call my-dir)
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 include $(CLEAR_VARS)
 

--- a/libretro.c
+++ b/libretro.c
@@ -696,7 +696,10 @@ void retro_get_system_info(struct retro_system_info* info)
    info->need_fullpath    = true;
 #endif
    info->valid_extensions = "smc|fig|sfc|gd3|gd7|dx2|bsx|swc";
-   info->library_version  = "v1.36";
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version  = "v1.36" GIT_VERSION;
 #ifdef USE_BLARGG_APU
    info->library_name     = "Snes9x 2005 Plus";
 #else


### PR DESCRIPTION
This patch makes this core report the git version as its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.