### PR TITLE
Report git version with library_version on Android

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,10 +1,11 @@
 LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
 GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
 ifneq ($(GIT_VERSION)," unknown")
 	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 endif
-
-include $(CLEAR_VARS)
 
 CORE_DIR     := ../source
 LIBRETRO_DIR := ..


### PR DESCRIPTION
This patch fixes GIT_VERSION on Android, which was missing due to bugs in Android.mk. Important for netplay between Android and non-Android systems.