### PR TITLE
Flush audio buffer at end of retro_run, and bypass resampler

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -456,6 +456,8 @@ void retro_run(void)
       audio_batch_cb(audio_buf, samples_to_play);
       samples_to_play = 0;
    }
+#else
+   S9xAudioCallback();
 #endif
 
 #ifdef NO_VIDEO_OUTPUT


### PR DESCRIPTION
Flushing the audio buffer at end of retro_run, and bypassing the resampler code to ensure no samples sitting in the resampler buffer after loading state.

This code matched up with snes9x2010 nicely, so the same fix is applied here.