### PR TITLE
[snes9x2005 non-plus] Fix audio pitch issues (FF6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ depend
 [Tt]humbs.db
 expsfc.*
 EXPSFC/
+*.so

--- a/source/apu.c
+++ b/source/apu.c
@@ -243,7 +243,7 @@ void S9xSetAPUDSP(uint8_t byte)
    case APU_P_LOW + 0x50:
    case APU_P_LOW + 0x60:
    case APU_P_LOW + 0x70:
-      S9xSetSoundHertz(reg >> 4, ((((int16_t) byte + ((int16_t) APU.DSP [reg + 1] << 8)) & FREQUENCY_MASK) * 32000) >> 12);
+      S9xSetSoundHertz(reg >> 4, (((int16_t) byte + ((int16_t) APU.DSP [reg + 1] << 8)) & FREQUENCY_MASK) * 8);
       break;
    case APU_P_HIGH + 0x00:
    case APU_P_HIGH + 0x10:


### PR DESCRIPTION
This PR adds the fix described in [snes9x2002 PR #29](https://github.com/libretro/snes9x2002/pull/29) to the snes9x2005 core (non-plus).