### PR TITLE
Map ExHiROM banks 2x{6,7} and ax{6,7} to SRAM

### DIFF
--- a/source/memmap.c
+++ b/source/memmap.c
@@ -1770,7 +1770,7 @@ void TalesROMMap(bool Interleaved)
 
       /* makes more sense to map the range here. */
       /* ToP seems to use sram to skip intro??? */
-      if (c >= 0x300)
+      if (c >= 0x200)
       {
          Memory.Map [c + 6] = Memory.Map [c + 0x806] = MAP_HIROM_SRAM_OR_NONE;
          Memory.Map [c + 7] = Memory.Map [c + 0x807] = MAP_HIROM_SRAM_OR_NONE;


### PR DESCRIPTION
These banks were previously unmapped, but are used by the Link to the Past / Super Metroid randomizer. According to fullsnes.txt and newer versions of snes9x, these should be mapped to SRAM.