### PR TITLE
Ensure frameskip counter is reset when a frame is rendered

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -614,6 +614,8 @@ void retro_run(void)
          else
             frameskip_counter = 0;
       }
+      else
+         frameskip_counter = 0;
    }
 
    /* If frameskip/timing settings have changed,


### PR DESCRIPTION
When frame skipping is enabled, the core uses a counter to limit the number of consecutive frames that can be dropped (to prevent the display from hanging indefinitely). This counter should be reset each time that a frame is actually rendered, but due to a small oversight it is not (apologies!). This means it is possible for a frame that should be dropped to be rendered instead, once every 30 times that a frame skip is requested. Most users probably wouldn't notice this, but it's incorrect behaviour...

This trivial PR fixes the issue.