### PR TITLE
Call S9xSoftReset() instead of S9xReset(), like newer Snes9x cores do

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -689,7 +689,7 @@ void retro_get_system_av_info(struct retro_system_av_info* info)
 void retro_reset(void)
 {
    CPU.Flags = 0;
-   S9xReset();
+   S9xSoftReset();
 }
 
 size_t retro_serialize_size(void)


### PR DESCRIPTION
This allows it to keep some state, e.g. which class in Super Mario Kart.