### PR TITLE
Microoptimisations

### DIFF
--- a/source/dsp1.c
+++ b/source/dsp1.c
@@ -352,7 +352,7 @@ void DSP1SetByte(uint8_t byte, uint16_t address)
                   Op11m = (int16_t)(DSP1.parameters [0] | (DSP1.parameters[1] << 8));
                   Op11Zr = (int16_t)(DSP1.parameters [2] | (DSP1.parameters[3] << 8));
                   Op11Yr = (int16_t)(DSP1.parameters [4] | (DSP1.parameters[5] << 8));
-                  Op11Xr = (int16_t)(DSP1.parameters [7] | (DSP1.parameters[7] << 8));
+                  Op11Xr = (int16_t)(DSP1.parameters [6] | (DSP1.parameters[7] << 8));
                   DSPOp11();
                   break;
                case 0x25:

--- a/source/gfx.c
+++ b/source/gfx.c
@@ -423,7 +423,7 @@ void S9xStartScreenRefresh(void)
       GFX.Delta = (GFX.SubScreen - GFX.Screen) >> 1;
    }
 
-   if (++IPPU.FrameCount % Memory.ROMFramesPerSecond == 0)
+   if (++IPPU.FrameCount == (uint32_t)Memory.ROMFramesPerSecond)
       IPPU.FrameCount = 0;
 }
 


### PR DESCRIPTION
A few microoptimisations noticed during code inspection, merged upstream in snes9xgit/snes9x#735 and libretro/snes9x2010#156.
I've opted to only fix the assignment of Op11Xr in patch 2 instead of wholesale replacement with {READ,WRITE}_WORD to minimise code churn.
Patch 3 benefits fewer little-endian platforms on this older fork as `port.h` has fewer LE platforms with a fast version of {READ,WRITE}_WORD, basically just x86 and Alpha.