### PR TITLE
platform/miyoo: Use optimised build flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,7 @@ else ifeq ($(platform), miyoo)
 	SHARED := -shared -Wl,--version-script=link.T
 	LIBM :=
 	FLAGS += -fomit-frame-pointer -ffast-math -march=armv5te -mtune=arm926ej-s
+	FLAGS += -DFAST_ALIGNED_LSB_WORD_ACCESS -fno-unroll-loops
 
 # (armv7 a7, hard point, neon based) ### 
 # NESC, SNESC, C64 mini 


### PR DESCRIPTION
Opt-in to FAST_ALIGNED_LSB_WORD_ACCESS optimisation which was actually
backported to a standalone fork in m45t3r/snes9x4d@cf6dedb1. Speeds up
some CPU and PPU operations.

Similarly, stop unrolling loops as in m45t3r/snes9x4d@8a342cde to help
small CPU cache devices like the Miyoo.