### PR TITLE
Fix audio sample pacing

### DIFF
--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -66,7 +66,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
 
    {
       "snes9x_2005_region",
-      "Console Region",
+      "Console Region (Restart)",
       NULL,
       "Specify which region the system is from. 'PAL' is 50hz, 'NTSC' is 60hz. Games will run faster or slower than normal if the incorrect region is selected.",
       NULL,

--- a/source/apu_blargg.c
+++ b/source/apu_blargg.c
@@ -2849,7 +2849,7 @@ void spc_copy_state( uint8_t ** io, dsp_copy_func_t copy )
  APU
 ***********************************************************************************/
 
-#define APU_DEFAULT_INPUT_RATE		32000
+#define APU_DEFAULT_INPUT_RATE		32040
 #define APU_MINIMUM_SAMPLE_COUNT	(512*8)
 #define APU_MINIMUM_SAMPLE_BLOCK	(128*8)
 #define APU_NUMERATOR_NTSC		15664
@@ -3177,8 +3177,8 @@ bool S9xInitSound (int32_t buffer_ms, int32_t lag_ms)
       lag_ms    : allowable time-lag given in millisecond */
    int32_t sample_count, lag_sample_count;
 
-   sample_count     = buffer_ms * 32000 / 1000;
-   lag_sample_count = lag_ms    * 32000 / 1000;
+   sample_count     = buffer_ms * 32040 / 1000;
+   lag_sample_count = lag_ms    * 32040 / 1000;
 
    lag_master = lag_sample_count;
 

--- a/source/memmap.c
+++ b/source/memmap.c
@@ -217,7 +217,7 @@ static int32_t ScoreLoROM(bool skip_header, int32_t romoff)
 
 static char* Safe(const char* s)
 {
-   static char* safe;
+   static char* safe = NULL;
    static int32_t safe_len = 0;
    int32_t i;
    int32_t len;
@@ -338,7 +338,7 @@ void S9xDeinitMemory(void)
       Memory.BSRAM = NULL;
    }
 
-   for (t = 0; t < 2; t++)
+   for (t = 0; t <= TILE_8BIT; t++)
    {
       if (IPPU.TileCache[t])
       {
@@ -351,6 +351,10 @@ void S9xDeinitMemory(void)
          IPPU.TileCached[t] = NULL;
       }
    }
+
+   /* Ensure that we free the static char
+    * array allocated by Safe() */
+   Safe(NULL);
 }
 
 #ifndef LOAD_FROM_MEMORY

--- a/source/soundux.c
+++ b/source/soundux.c
@@ -211,7 +211,7 @@ void S9xSetEchoFeedback(int32_t feedback)
 
 void S9xSetEchoDelay(int32_t delay)
 {
-   SoundData.echo_buffer_size = (512 * delay * so.playback_rate) / 32000;
+   SoundData.echo_buffer_size = (512 * delay * so.playback_rate) / 32040;
    SoundData.echo_buffer_size <<= 1;
    if (SoundData.echo_buffer_size)
       SoundData.echo_ptr %= SoundData.echo_buffer_size;


### PR DESCRIPTION
At present, the core has bad audio sample pacing:

- Neither variant of the core sends a number of samples per frame that match the nominal expected values given by the sample rate and fps set in `retro_get_system_av_info()`
- Due to integer rounding errors, the non-plus core always sends too few samples
- The 'plus' version of the core sends the 'correct' number of samples, in terms of actual emulation - but this does not tally with the sample rate reported to the frontend. Moreover, the 'plus' core calls the audio batch callback twice per frame, which unduly stresses the frontend audio buffer

As a result, the core has bad audio/video synchronisation, affecting frame pacing.

This PR fixes the issue:

- The audio sample rate is now reported as 32040 Hz
- The non-plus core uses an accumulator to ensure that 'fractional' audio samples are accounted for and sent when required
- The plus core now uploads audio samples only once per frame

In addition, the PR:

- Fixes three memory leaks that were found in the core
- Modifies the `Console Region` core option to require a restart (since it has never been possible to change this at runtime...)