### PR TITLE
Snes9x2005 Non-Plus: Add optional low pass audio filter

### DIFF
--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -122,6 +122,53 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       },
       "33"
    },
+#ifndef USE_BLARGG_APU
+   {
+      "snes9x_2005_low_pass_filter",
+      "Audio Filter",
+      NULL,
+      "Enable a low pass audio filter to soften treble artifacts and mimic the 'bassy' sound of original SNES hardware.",
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "snes9x_2005_low_pass_range",
+      "Audio Filter Level",
+      NULL,
+      "Specify the cut-off frequency of the low pass audio filter. A higher value increases the perceived 'strength' of the filter, since a wider range of the high frequency spectrum is attenuated.",
+      NULL,
+      NULL,
+      {
+         { "5",  "5%" },
+         { "10", "10%" },
+         { "15", "15%" },
+         { "20", "20%" },
+         { "25", "25%" },
+         { "30", "30%" },
+         { "35", "35%" },
+         { "40", "40%" },
+         { "45", "45%" },
+         { "50", "50%" },
+         { "55", "55%" },
+         { "60", "60%" },
+         { "65", "65%" },
+         { "70", "70%" },
+         { "75", "75%" },
+         { "80", "80%" },
+         { "85", "85%" },
+         { "90", "90%" },
+         { "95", "95%" },
+         { NULL, NULL },
+      },
+      "60"
+   },
+#endif
    {
       "snes9x_2005_overclock_cycles",
       "Reduce Slowdown (Hack, Unsafe, Restart)",

--- a/source/soundux.h
+++ b/source/soundux.h
@@ -135,6 +135,7 @@ void S9xFixEnvelope(int32_t channel, uint8_t gain, uint8_t adsr1, uint8_t adsr2)
 void S9xStartSample(int32_t channel);
 
 void S9xMixSamples(int16_t* buffer, int32_t sample_count);
+void S9xMixSamplesLowPass(int16_t* buffer, int32_t sample_count, int32_t low_pass_range);
 void S9xSetPlaybackRate(uint32_t rate);
 #endif
 #endif


### PR DESCRIPTION
Apart from a substantial difference in audio emulation accuracy, probably the most obvious difference between the 'plus' and 'non-plus' versions of the core is that the latter has an inadequate level of low pass audio filtering, leading to tinny/scratchy sound.

This PR adds a simple optional low pass filter at the output stage of the 'non-plus' core. When enabled, audio is more mellow/bassy, and the generated sound is closer to that produced by the 'plus' version - with only a negligible increase in performance requirements.