### PR TITLE
libretro: fix S9xSetSoundMute prototype

### DIFF
--- a/source/apu_blargg.h
+++ b/source/apu_blargg.h
@@ -292,5 +292,7 @@ void    S9xClearSamples();
 bool    S9xMixSamples(int16_t * buffer, uint32_t sample_count);
 void    S9xSetSamplesAvailableCallback(apu_callback);
 
+void S9xSetSoundMute(bool mute);
+
 #endif /* APU_BLARGG_H */
 #endif


### PR DESCRIPTION
Fixes

```
snes9x2005: [x86_64] Compile : retro <= libretro.c /builds/libretro/snes9x2005/jni/../libretro.c:657:7: error: call to undeclared function 'S9xSetSoundMute'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration] 657 | S9xSetSoundMute(!audioEnabled || hardDisableAudio); | ^ /builds/libretro/snes9x2005/jni/../libretro.c:665:7: error: call to undeclared function 'S9xSetSoundMute'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration] 665 | source/apu_blargg.c: S9xSetSoundMute(false); void S9xSetSoundMute(bool mute) { Settings.Mute = mute; } | ^ 2 errors generated.
```